### PR TITLE
fix: add explicit action:route to custom warp-ep route rules

### DIFF
--- a/sing-box.sh
+++ b/sing-box.sh
@@ -1281,7 +1281,7 @@ custom_route_compact_rules() {
       (if (($domains | length) + ($sets | length)) > 0 then
         [((if ($sets | length) > 0 then {rule_set:$sets} else {} end)
           + (if ($domains | length) > 0 then {domain_suffix:$domains} else {} end)
-          + {outbound:"warp-ep"})]
+          + {action:"route", outbound:"warp-ep"})]
       else [] end)
     )
   ' "$CUSTOM_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$CUSTOM_FILE"
@@ -1436,7 +1436,7 @@ custom_route_add() {
         (if (($new_domains | length) + ($new_sets | length)) > 0 then
           [((if ($new_sets | length) > 0 then {rule_set:$new_sets} else {} end)
             + (if ($new_domains | length) > 0 then {domain_suffix:$new_domains} else {} end)
-            + {outbound:$out})]
+            + {action:"route", outbound:$out})]
         else [] end)
       )
     ' "$CUSTOM_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$CUSTOM_FILE"
@@ -1474,7 +1474,7 @@ custom_route_add() {
         (if (($new_domains | length) + ($new_sets | length)) > 0 then
           [((if ($new_sets | length) > 0 then {rule_set:$new_sets} else {} end)
             + (if ($new_domains | length) > 0 then {domain_suffix:$new_domains} else {} end)
-            + {outbound:$out})]
+            + {action:"route", outbound:$out})]
         else [] end)
       )
     ' "$CUSTOM_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$CUSTOM_FILE"


### PR DESCRIPTION
### Problem

The `custom_route_add()` and `custom_route_compact_rules()` functions generate route rules with bare `{"outbound":"warp-ep"}`, which has been **deprecated since sing-box 1.11.0** in favor of `{"action":"route","outbound":...}`.

With sing-box 1.14.0-alpha.38+, the missing `action` field causes startup failures:
```
FATAL initialize rule-set: detour to an empty direct outbound makes no sense
```

sing-box 1.14.0-alpha.37 and earlier accept both formats.

### Changes

Three lines changed, adding `"action":"route"` to the route rule construction:

| Location | Line | Change |
| --- | --- | --- |
| `custom_route_compact_rules` | 1284 | `{outbound:"warp-ep"}` → `{action:"route",outbound:"warp-ep"}` |
| `custom_route_add` (domain_suffix) | 1439 | `{outbound:$out}` → `{action:"route",outbound:$out}` |
| `custom_route_add` (rule_set) | 1477 | `{outbound:$out}` → `{action:"route",outbound:$out}` |

The Hysteria2 WARP helper at line 1244 already uses correct format `{"action":"route","outbound":"warp-ep"}` and is not modified.

### Testing

Tested with sing-box 1.14.0-alpha.39: config check passes, service runs correctly with custom warp-ep rules.