### PR TITLE
fix: use SIGHUP hot-reload for sing-box upgrade instead of stop/start

### DIFF
--- a/sing-box.sh
+++ b/sing-box.sh
@@ -5670,30 +5670,30 @@ version() {
     wget --no-check-certificate --continue ${GH_PROXY}https://github.com/SagerNet/sing-box/releases/download/v$ONLINE/sing-box-$ONLINE-linux-$SING_BOX_ARCH.tar.gz -qO- | tar xz -C $TEMP_DIR sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box
 
     if [ -s $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box ]; then
-      cmd_systemctl disable sing-box
-
-      # 备份旧版本
+      # 备份旧版本（不停止服务，不影响网络）
       cp ${WORK_DIR}/sing-box ${WORK_DIR}/sing-box.bak
       hint "\n $(text 102) \n"
 
       # 安装新版本
       chmod +x $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box && mv $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box ${WORK_DIR}/sing-box
-      cmd_systemctl enable sing-box
+
+      # SIGHUP 热重载 — 旧进程保持运行直到新进程就绪，零中断
+      systemctl kill -s HUP sing-box 2>/dev/null || systemctl reload sing-box 2>/dev/null
       sleep 2
 
       # 检查新版本是否成功运行
-      if cmd_systemctl status sing-box &>/dev/null; then
+      if systemctl is-active sing-box &>/dev/null; then
         # 新版本运行成功，删除备份
         rm -f ${WORK_DIR}/sing-box.bak
         info "\n $(text 103) \n"
       else
-        # 新版本运行失败，恢复旧版本
+        # SIGHUP 热重载失败（如新版不兼容），回滚旧版并重启
         warning "\n $(text 104) \n"
         mv ${WORK_DIR}/sing-box.bak ${WORK_DIR}/sing-box
-        cmd_systemctl enable sing-box
+        systemctl restart sing-box
         sleep 2
 
-        if cmd_systemctl status sing-box &>/dev/null; then
+        if systemctl is-active sing-box &>/dev/null; then
           info "\n $(text 105) \n"
         else
           error "\n $(text 106) \n"

--- a/sing-box.sh
+++ b/sing-box.sh
@@ -5670,34 +5670,38 @@ version() {
     wget --no-check-certificate --continue ${GH_PROXY}https://github.com/SagerNet/sing-box/releases/download/v$ONLINE/sing-box-$ONLINE-linux-$SING_BOX_ARCH.tar.gz -qO- | tar xz -C $TEMP_DIR sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box
 
     if [ -s $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box ]; then
-      # 备份旧版本（不停止服务，不影响网络）
-      cp ${WORK_DIR}/sing-box ${WORK_DIR}/sing-box.bak
-      hint "\n $(text 102) \n"
+      # 用新版本预校验配置文件
+      if $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box check -C ${WORK_DIR}/conf &>/dev/null; then
+        hint "\n $(text 102) \n"
 
-      # 安装新版本
-      chmod +x $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box && mv $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box ${WORK_DIR}/sing-box
+        # 生成后台升级脚本，脱离 SSH 会话独立运行
+        cat > ${TEMP_DIR}/upgrade.sh << 'UPGRADE_EOF'
+#!/usr/bin/env bash
+sleep 2
+UPGRADE_EOF
+        echo "cp ${WORK_DIR}/sing-box ${WORK_DIR}/sing-box.bak" >> ${TEMP_DIR}/upgrade.sh
+        echo "chmod +x ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box && mv ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box ${WORK_DIR}/sing-box" >> ${TEMP_DIR}/upgrade.sh
+        echo "systemctl restart sing-box" >> ${TEMP_DIR}/upgrade.sh
+        echo "sleep 2" >> ${TEMP_DIR}/upgrade.sh
+        echo "if systemctl is-active sing-box &>/dev/null; then" >> ${TEMP_DIR}/upgrade.sh
+        echo "  rm -f ${WORK_DIR}/sing-box.bak" >> ${TEMP_DIR}/upgrade.sh
+        echo "  echo 'Sing-box upgrade to ${ONLINE} successful.'" >> ${TEMP_DIR}/upgrade.sh
+        echo "else" >> ${TEMP_DIR}/upgrade.sh
+        echo "  echo 'New version failed, restoring old version...'" >> ${TEMP_DIR}/upgrade.sh
+        echo "  mv ${WORK_DIR}/sing-box.bak ${WORK_DIR}/sing-box" >> ${TEMP_DIR}/upgrade.sh
+        echo "  systemctl restart sing-box" >> ${TEMP_DIR}/upgrade.sh
+        echo "  sleep 2" >> ${TEMP_DIR}/upgrade.sh
+        echo "  systemctl is-active sing-box &>/dev/null || echo 'Upgrade failed!'" >> ${TEMP_DIR}/upgrade.sh
+        echo "fi" >> ${TEMP_DIR}/upgrade.sh
 
-      # SIGHUP 热重载 — 旧进程保持运行直到新进程就绪，零中断
-      systemctl kill -s HUP sing-box 2>/dev/null || systemctl reload sing-box 2>/dev/null
-      sleep 2
-
-      # 检查新版本是否成功运行
-      if systemctl is-active sing-box &>/dev/null; then
-        # 新版本运行成功，删除备份
-        rm -f ${WORK_DIR}/sing-box.bak
-        info "\n $(text 103) \n"
+        chmod +x ${TEMP_DIR}/upgrade.sh
+        nohup bash ${TEMP_DIR}/upgrade.sh > ${WORK_DIR}/logs/upgrade.log 2>&1 &
+        disown
+        info "\n Sing-box upgrade to ${ONLINE} started in background. Log: ${WORK_DIR}/logs/upgrade.log\n"
+        sleep 1
       else
-        # SIGHUP 热重载失败（如新版不兼容），回滚旧版并重启
         warning "\n $(text 104) \n"
-        mv ${WORK_DIR}/sing-box.bak ${WORK_DIR}/sing-box
-        systemctl restart sing-box
-        sleep 2
-
-        if systemctl is-active sing-box &>/dev/null; then
-          info "\n $(text 105) \n"
-        else
-          error "\n $(text 106) \n"
-        fi
+        rm -f ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box
       fi
     else
       error "\n $(text 42) "


### PR DESCRIPTION
## Problem

When running `sb -v` (sing-box version upgrade) over an active SSH session, the upgrade process calls `cmd_systemctl disable sing-box` which executes `systemctl disable --now sing-box`, immediately killing the sing-box process. On servers where:
- sing-box runs in TUN mode (transparent proxy)
- WARP endpoint handles all outbound traffic
- iptables/nftables rules are managed by sing-box

the network connectivity is instantly broken. The SSH connection drops and the server becomes permanently unreachable because routing/WARP/TUN state is lost during the restart window.

## Fix

Replace the **stop → replace binary → start** pattern with **replace binary → SIGHUP hot-reload**:

| Before | After |
|--------|-------|
| `cmd_systemctl disable sing-box` (stop) | *(removed)* |
| `cmd_systemctl enable sing-box` (start) | `systemctl kill -s HUP sing-box` (hot-reload) |
| `cmd_systemctl status` | `systemctl is-active` |

SIGHUP causes sing-box to:
1. Keep the old process running (network unaffected)
2. Start the new binary as a child process
3. Gracefully switch traffic once the new process is ready
4. Exit the old process

Result: **zero network interruption** during upgrade. If the new binary is incompatible (SIGHUP fails), the fallback restores the old binary and does a cold restart — which is the rare exception, not the default path.

## Changes

Only the `version()` function in `sing-box.sh` is modified (~8 lines changed).