### PR TITLE
fix: pre-validate with sing-box check + background upgrade to avoid SSH lockout

### DIFF
--- a/sing-box.sh
+++ b/sing-box.sh
@@ -5670,30 +5670,30 @@ version() {
     wget --no-check-certificate --continue ${GH_PROXY}https://github.com/SagerNet/sing-box/releases/download/v$ONLINE/sing-box-$ONLINE-linux-$SING_BOX_ARCH.tar.gz -qO- | tar xz -C $TEMP_DIR sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box
 
     if [ -s $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box ]; then
-      cmd_systemctl disable sing-box
-
-      # 备份旧版本
+      # 备份旧版本（不停止服务，不影响网络）
       cp ${WORK_DIR}/sing-box ${WORK_DIR}/sing-box.bak
       hint "\n $(text 102) \n"
 
       # 安装新版本
       chmod +x $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box && mv $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box ${WORK_DIR}/sing-box
-      cmd_systemctl enable sing-box
+
+      # SIGHUP 热重载 — 旧进程保持运行直到新进程就绪，零中断
+      systemctl kill -s HUP sing-box 2>/dev/null || systemctl reload sing-box 2>/dev/null
       sleep 2
 
       # 检查新版本是否成功运行
-      if cmd_systemctl status sing-box &>/dev/null; then
+      if systemctl is-active sing-box &>/dev/null; then
         # 新版本运行成功，删除备份
         rm -f ${WORK_DIR}/sing-box.bak
         info "\n $(text 103) \n"
       else
-        # 新版本运行失败，恢复旧版本
+        # SIGHUP 热重载失败（如新版不兼容），回滚旧版并重启
         warning "\n $(text 104) \n"
         mv ${WORK_DIR}/sing-box.bak ${WORK_DIR}/sing-box
-        cmd_systemctl enable sing-box
+        systemctl restart sing-box
         sleep 2
 
-        if cmd_systemctl status sing-box &>/dev/null; then
+        if systemctl is-active sing-box &>/dev/null; then
           info "\n $(text 105) \n"
         else
           error "\n $(text 106) \n"

--- a/sing-box.sh
+++ b/sing-box.sh
@@ -5670,34 +5670,38 @@ version() {
     wget --no-check-certificate --continue ${GH_PROXY}https://github.com/SagerNet/sing-box/releases/download/v$ONLINE/sing-box-$ONLINE-linux-$SING_BOX_ARCH.tar.gz -qO- | tar xz -C $TEMP_DIR sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box
 
     if [ -s $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box ]; then
-      # 备份旧版本（不停止服务，不影响网络）
-      cp ${WORK_DIR}/sing-box ${WORK_DIR}/sing-box.bak
-      hint "\n $(text 102) \n"
+      # 用新版本预校验配置文件
+      if $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box check -C ${WORK_DIR}/conf &>/dev/null; then
+        hint "\n $(text 102) \n"
 
-      # 安装新版本
-      chmod +x $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box && mv $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box ${WORK_DIR}/sing-box
+        # 生成后台升级脚本，脱离 SSH 会话独立运行
+        cat > ${TEMP_DIR}/upgrade.sh << 'UPGRADE_EOF'
+#!/usr/bin/env bash
+sleep 2
+UPGRADE_EOF
+        echo "cp ${WORK_DIR}/sing-box ${WORK_DIR}/sing-box.bak" >> ${TEMP_DIR}/upgrade.sh
+        echo "chmod +x ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box && mv ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box ${WORK_DIR}/sing-box" >> ${TEMP_DIR}/upgrade.sh
+        echo "systemctl restart sing-box" >> ${TEMP_DIR}/upgrade.sh
+        echo "sleep 2" >> ${TEMP_DIR}/upgrade.sh
+        echo "if systemctl is-active sing-box &>/dev/null; then" >> ${TEMP_DIR}/upgrade.sh
+        echo "  rm -f ${WORK_DIR}/sing-box.bak" >> ${TEMP_DIR}/upgrade.sh
+        echo "  echo 'Sing-box upgrade to ${ONLINE} successful.'" >> ${TEMP_DIR}/upgrade.sh
+        echo "else" >> ${TEMP_DIR}/upgrade.sh
+        echo "  echo 'New version failed, restoring old version...'" >> ${TEMP_DIR}/upgrade.sh
+        echo "  mv ${WORK_DIR}/sing-box.bak ${WORK_DIR}/sing-box" >> ${TEMP_DIR}/upgrade.sh
+        echo "  systemctl restart sing-box" >> ${TEMP_DIR}/upgrade.sh
+        echo "  sleep 2" >> ${TEMP_DIR}/upgrade.sh
+        echo "  systemctl is-active sing-box &>/dev/null || echo 'Upgrade failed!'" >> ${TEMP_DIR}/upgrade.sh
+        echo "fi" >> ${TEMP_DIR}/upgrade.sh
 
-      # SIGHUP 热重载 — 旧进程保持运行直到新进程就绪，零中断
-      systemctl kill -s HUP sing-box 2>/dev/null || systemctl reload sing-box 2>/dev/null
-      sleep 2
-
-      # 检查新版本是否成功运行
-      if systemctl is-active sing-box &>/dev/null; then
-        # 新版本运行成功，删除备份
-        rm -f ${WORK_DIR}/sing-box.bak
-        info "\n $(text 103) \n"
+        chmod +x ${TEMP_DIR}/upgrade.sh
+        nohup bash ${TEMP_DIR}/upgrade.sh > ${WORK_DIR}/logs/upgrade.log 2>&1 &
+        disown
+        info "\n Sing-box upgrade to ${ONLINE} started in background. Log: ${WORK_DIR}/logs/upgrade.log\n"
+        sleep 1
       else
-        # SIGHUP 热重载失败（如新版不兼容），回滚旧版并重启
         warning "\n $(text 104) \n"
-        mv ${WORK_DIR}/sing-box.bak ${WORK_DIR}/sing-box
-        systemctl restart sing-box
-        sleep 2
-
-        if systemctl is-active sing-box &>/dev/null; then
-          info "\n $(text 105) \n"
-        else
-          error "\n $(text 106) \n"
-        fi
+        rm -f ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box
       fi
     else
       error "\n $(text 42) "

--- a/sing-box.sh
+++ b/sing-box.sh
@@ -5674,62 +5674,36 @@ version() {
       if $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box check -C ${WORK_DIR}/conf &>/dev/null; then
         hint "\n $(text 102) \n"
 
-        # 生成后台升级脚本，脱离 SSH 会话独立运行
-        cat > ${TEMP_DIR}/upgrade.sh << UPGRADE_SCRIPT
-#!/usr/bin/env bash
-WORK_DIR='${WORK_DIR}'
-ONLINE='${ONLINE}'
-LOG="${WORK_DIR}/logs/upgrade-${ONLINE}-\$(date +%Y%m%d-%H%M%S).log"
-exec > "\$LOG" 2>&1
+        # 后台升级：subshell + disown，脱离 SSH 会话
+        (
+          sleep 2
+          mv ${WORK_DIR}/sing-box ${WORK_DIR}/sing-box.bak
+          chmod +x $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box
+          cp $TEMP_DIR/sing-box-$ONLINE-linux-$SING_BOX_ARCH/sing-box ${WORK_DIR}/sing-box
 
-# 兼容 systemd 和 OpenRC (Alpine)
-if command -v systemctl &>/dev/null; then
-  DAEMON_RELOAD() { systemctl daemon-reload; }
-  SERVICE_RESTART() { systemctl restart "\$1"; }
-  SERVICE_ACTIVE() { systemctl is-active "\$1" &>/dev/null; }
-else
-  DAEMON_RELOAD() { :; }
-  SERVICE_RESTART() { rc-service "\$1" restart; }
-  SERVICE_ACTIVE() { rc-service "\$1" status &>/dev/null; }
-fi
+          if command -v systemctl &>/dev/null; then
+            systemctl daemon-reload
+            systemctl restart sing-box
+          else
+            rc-service sing-box restart
+          fi
+          sleep 2
 
-echo "[upgrade] waiting 2s before upgrade..."
-sleep 2
-
-echo "[upgrade] backing up old binary"
-mv \${WORK_DIR}/sing-box \${WORK_DIR}/sing-box.bak
-
-echo "[upgrade] installing new binary"
-cp ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box \${WORK_DIR}/sing-box
-chmod +x \${WORK_DIR}/sing-box
-
-echo "[upgrade] restarting sing-box..."
-DAEMON_RELOAD
-SERVICE_RESTART sing-box
-sleep 2
-
-if SERVICE_ACTIVE sing-box; then
-  echo "[upgrade] ✅ new version ${ONLINE} is running. cleaning up..."
-  rm -f \${WORK_DIR}/sing-box.bak
-else
-  echo "[upgrade] ❌ new version failed to start. restoring old binary..."
-  rm -f \${WORK_DIR}/sing-box
-  mv \${WORK_DIR}/sing-box.bak \${WORK_DIR}/sing-box
-  DAEMON_RELOAD
-  SERVICE_RESTART sing-box
-  sleep 2
-  if SERVICE_ACTIVE sing-box; then
-    echo "[upgrade] ✅ rollback successful. old version restored."
-  else
-    echo "[upgrade] ❌ rollback also failed! manual intervention required."
-  fi
-fi
-UPGRADE_SCRIPT
-
-        chmod +x ${TEMP_DIR}/upgrade.sh
-        nohup bash ${TEMP_DIR}/upgrade.sh > /dev/null 2>&1 &
+          if systemctl is-active sing-box &>/dev/null || rc-service sing-box status &>/dev/null; then
+            rm -f ${WORK_DIR}/sing-box.bak
+          else
+            rm -f ${WORK_DIR}/sing-box
+            mv ${WORK_DIR}/sing-box.bak ${WORK_DIR}/sing-box
+            if command -v systemctl &>/dev/null; then
+              systemctl daemon-reload
+              systemctl restart sing-box
+            else
+              rc-service sing-box restart
+            fi
+          fi
+        ) > ${WORK_DIR}/logs/upgrade-${ONLINE}.log 2>&1 &
         disown
-        info "\n Sing-box upgrade to ${ONLINE} started in background. Log: ${WORK_DIR}/logs/upgrade-${ONLINE}-*.log\n"
+        info "\n Sing-box upgrade to ${ONLINE} started in background.\n"
       else
         warning "\n $(text 104) \n"
         rm -f ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box

--- a/sing-box.sh
+++ b/sing-box.sh
@@ -5675,30 +5675,61 @@ version() {
         hint "\n $(text 102) \n"
 
         # 生成后台升级脚本，脱离 SSH 会话独立运行
-        cat > ${TEMP_DIR}/upgrade.sh << 'UPGRADE_EOF'
+        cat > ${TEMP_DIR}/upgrade.sh << UPGRADE_SCRIPT
 #!/usr/bin/env bash
+WORK_DIR='${WORK_DIR}'
+ONLINE='${ONLINE}'
+LOG="${WORK_DIR}/logs/upgrade-${ONLINE}-\$(date +%Y%m%d-%H%M%S).log"
+exec > "\$LOG" 2>&1
+
+# 兼容 systemd 和 OpenRC (Alpine)
+if command -v systemctl &>/dev/null; then
+  DAEMON_RELOAD() { systemctl daemon-reload; }
+  SERVICE_RESTART() { systemctl restart "\$1"; }
+  SERVICE_ACTIVE() { systemctl is-active "\$1" &>/dev/null; }
+else
+  DAEMON_RELOAD() { :; }
+  SERVICE_RESTART() { rc-service "\$1" restart; }
+  SERVICE_ACTIVE() { rc-service "\$1" status &>/dev/null; }
+fi
+
+echo "[upgrade] waiting 2s before upgrade..."
 sleep 2
-UPGRADE_EOF
-        echo "cp ${WORK_DIR}/sing-box ${WORK_DIR}/sing-box.bak" >> ${TEMP_DIR}/upgrade.sh
-        echo "chmod +x ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box && mv ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box ${WORK_DIR}/sing-box" >> ${TEMP_DIR}/upgrade.sh
-        echo "systemctl restart sing-box" >> ${TEMP_DIR}/upgrade.sh
-        echo "sleep 2" >> ${TEMP_DIR}/upgrade.sh
-        echo "if systemctl is-active sing-box &>/dev/null; then" >> ${TEMP_DIR}/upgrade.sh
-        echo "  rm -f ${WORK_DIR}/sing-box.bak" >> ${TEMP_DIR}/upgrade.sh
-        echo "  echo 'Sing-box upgrade to ${ONLINE} successful.'" >> ${TEMP_DIR}/upgrade.sh
-        echo "else" >> ${TEMP_DIR}/upgrade.sh
-        echo "  echo 'New version failed, restoring old version...'" >> ${TEMP_DIR}/upgrade.sh
-        echo "  mv ${WORK_DIR}/sing-box.bak ${WORK_DIR}/sing-box" >> ${TEMP_DIR}/upgrade.sh
-        echo "  systemctl restart sing-box" >> ${TEMP_DIR}/upgrade.sh
-        echo "  sleep 2" >> ${TEMP_DIR}/upgrade.sh
-        echo "  systemctl is-active sing-box &>/dev/null || echo 'Upgrade failed!'" >> ${TEMP_DIR}/upgrade.sh
-        echo "fi" >> ${TEMP_DIR}/upgrade.sh
+
+echo "[upgrade] backing up old binary"
+mv \${WORK_DIR}/sing-box \${WORK_DIR}/sing-box.bak
+
+echo "[upgrade] installing new binary"
+cp ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box \${WORK_DIR}/sing-box
+chmod +x \${WORK_DIR}/sing-box
+
+echo "[upgrade] restarting sing-box..."
+DAEMON_RELOAD
+SERVICE_RESTART sing-box
+sleep 2
+
+if SERVICE_ACTIVE sing-box; then
+  echo "[upgrade] ✅ new version ${ONLINE} is running. cleaning up..."
+  rm -f \${WORK_DIR}/sing-box.bak
+else
+  echo "[upgrade] ❌ new version failed to start. restoring old binary..."
+  rm -f \${WORK_DIR}/sing-box
+  mv \${WORK_DIR}/sing-box.bak \${WORK_DIR}/sing-box
+  DAEMON_RELOAD
+  SERVICE_RESTART sing-box
+  sleep 2
+  if SERVICE_ACTIVE sing-box; then
+    echo "[upgrade] ✅ rollback successful. old version restored."
+  else
+    echo "[upgrade] ❌ rollback also failed! manual intervention required."
+  fi
+fi
+UPGRADE_SCRIPT
 
         chmod +x ${TEMP_DIR}/upgrade.sh
-        nohup bash ${TEMP_DIR}/upgrade.sh > ${WORK_DIR}/logs/upgrade.log 2>&1 &
+        nohup bash ${TEMP_DIR}/upgrade.sh > /dev/null 2>&1 &
         disown
-        info "\n Sing-box upgrade to ${ONLINE} started in background. Log: ${WORK_DIR}/logs/upgrade.log\n"
-        sleep 1
+        info "\n Sing-box upgrade to ${ONLINE} started in background. Log: ${WORK_DIR}/logs/upgrade-${ONLINE}-*.log\n"
       else
         warning "\n $(text 104) \n"
         rm -f ${TEMP_DIR}/sing-box-${ONLINE}-linux-${SING_BOX_ARCH}/sing-box


### PR DESCRIPTION
## Problem

Running `sb -v` over an active SSH session: `systemctl disable --now` kills sing-box immediately. On servers using TUN mode / WARP endpoint / iptables rules managed by sing-box, the network breaks and the server becomes **permanently unreachable**.

## Fix

Two changes to the `version()` function:

### 1. Pre-validate with `sing-box check`

```bash
$TEMP_DIR/sing-box check -C ${WORK_DIR}/conf
```
Before touching the live binary, run the new version against the existing config. Abort on failure.

### 2. Subshell + disown (background upgrade)

Replace the inline stop → replace → start with a subshell that runs independently:

```bash
(
  sleep 2              # let SSH session exit cleanly
  mv .bak              # rename old binary (avoids "Text file busy")
  cp new-binary        # place new version
  systemctl restart    # or rc-service on Alpine
  check + rollback
) > log 2>&1 &
disown
```

The subshell inherits all variables naturally — no temp script files, no fragile heredoc escaping.

### Compatibility

- systemd (Debian/Ubuntu/CentOS/Fedora/Arch) ✓
- OpenRC (Alpine) ✓
- Rollback on failure ✓

### Changes

Only `version()` in `sing-box.sh` (~28 lines).